### PR TITLE
Fix for tube names.

### DIFF
--- a/beanstalk/protohandler.py
+++ b/beanstalk/protohandler.py
@@ -215,7 +215,7 @@ def interaction(*responses):
         return newfunc
     return deco
 
-_namematch = re.compile(r'^[a-zA-Z0-9+\(\);.$][a-zA-Z0-9+\(\);.$-]{0,199}$')
+_namematch = re.compile(r'^[a-zA-Z0-9+\(\)/;.$_][a-zA-Z0-9+\(\)/;.$_-]{0,199}$')
 def check_name(name):
     '''used to check the validity of a tube name'''
     if not _namematch.match(name):

--- a/tests/test_Proto.py
+++ b/tests/test_Proto.py
@@ -212,3 +212,5 @@ def test_put_extra():
     protohandler.MAX_JOB_SIZE = oldmax
 
 
+def test_tube_name():
+    assert(protohandler._namematch.match("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-+/;.$_()"))


### PR DESCRIPTION
Hey,

Here's a quick fix that makes pybeanstalk consistent with current tube name conventions.

Cheers,
jan
