### PR TITLE
Fixed a NameError exception when trying to reference 'server'.

### DIFF
--- a/beanstalk/serverconn.py
+++ b/beanstalk/serverconn.py
@@ -83,8 +83,8 @@ class ServerConn(object):
             recv = self._socket.recv(handler.remaining)
             if not recv:
                 closedmsg = "Remote server %(server)s:%(port)s has "\
-                            "closed connection" % { "server" : server.ip,
-                                                    "port" : server.port}
+                            "closed connection" % { "server" : self.server.ip,
+                                                    "port" : self.server.port}
                 self.close()
                 raise protohandler.errors.ProtoError(closedmsg)
             res = handler(recv)


### PR DESCRIPTION
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 552, in __bootstrap_inner
    self.run()
  File "Dispatcher.py", line 79, in run
    job = self.bs.reserve_with_timeout(420)
  File "/usr/local/lib/python2.7/dist-packages/beanstalk/serverconn.py", line 51, in caller
    return self._do_interaction(*res(*args, **kw))
  File "/usr/local/lib/python2.7/dist-packages/beanstalk/serverconn.py", line 99, in _do_interaction
    return self._get_response(handler)
  File "/usr/local/lib/python2.7/dist-packages/beanstalk/serverconn.py", line 86, in _get_response
    "closed connection" % { "server" : server.ip,
NameError: global name 'server' is not defined
