### PR TITLE
error while import LibevenConn

### DIFF
--- a/beanstalk/_libeventconn.py
+++ b/beanstalk/_libeventconn.py
@@ -1,5 +1,4 @@
 import socket, sys
-from collections import dequeue
 import protohandler
 
 class Command(object):


### PR DESCRIPTION
I removed the unused import. this also caused an error while importing LibevenConn.
the correct import was from collections import deque, but I remoed it since it was unused.
