### PR TITLE
Beanstalk implements IProtocol, ILoggingContext

### DIFF
--- a/beanstalk/twisted_client.py
+++ b/beanstalk/twisted_client.py
@@ -1,7 +1,8 @@
 from twisted.protocols import basic
-from twisted.internet import defer, protocol
+from twisted.internet import interfaces, defer, protocol
 from twisted.python import log
 import protohandler
+from zope.interface import implementer
 
 # Stolen from memcached protocol
 try:
@@ -58,6 +59,7 @@ class Command(object):
         """
         self._deferred.errback(error)
 
+@implementer(interfaces.IProtocol, interfaces.ILoggingContext)
 class Beanstalk(basic.LineReceiver):
 
     def __init__(self):


### PR DESCRIPTION
It fixed error:

```
Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/python/log.py", line 88, in callWithLogger
    return callWithContext({"system": lp}, func, *args, **kw)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/python/log.py", line 73, in callWithContext
    return context.call({ILogContext: newCtx}, func, *args, **kw)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/python/context.py", line 118, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/python/context.py", line 81, in callWithContext
    return func(*args,**kw)
--- <exception caught here> ---
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/posixbase.py", line 619, in _doReadOrWrite
    why = selectable.doWrite()
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/tcp.py", line 593, in doConnect
    self._connectDone()
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/tcp.py", line 609, in _connectDone
    logPrefix = self._getLogPrefix(self.protocol)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/abstract.py", line 141, in _getLogPrefix
    if interfaces.ILoggingContext.providedBy(applicationObject):
  File "/usr/local/lib/python2.6/dist-packages/beanstalk/twisted_client.py", line 73, in caller
    *getattr(protohandler, 'process_%s' % attr)(*args, **kw))
exceptions.AttributeError: 'module' object has no attribute 'process___provides__'
Unhandled error in Deferred:
Unhandled Error
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/base.py", line 805, in runUntilCurrent
    call.func(*call.args, **call.kw)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/protocol.py", line 190, in fire
    func(value)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 381, in callback
    self._startRunCallbacks(result)
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 489, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/usr/local/lib/python2.6/dist-packages/Twisted-12.3.0-py2.6-linux-x86_64.egg/twisted/internet/defer.py", line 576, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "t.py", line 27, in worker
    bs.watch("myqueue")
  File "/usr/local/lib/python2.6/dist-packages/beanstalk/twisted_client.py", line 73, in caller
    *getattr(protohandler, 'process_%s' % attr)(*args, **kw))
  File "/usr/local/lib/python2.6/dist-packages/beanstalk/twisted_client.py", line 79, in __cmd
    self.transport.write(full_command)
exceptions.AttributeError: 'NoneType' object has no attribute 'write'
```
