### PR TITLE
Erroneous newline truncation when reserving

### DIFF
--- a/beanstalk/protohandler.py
+++ b/beanstalk/protohandler.py
@@ -186,7 +186,7 @@ class Handler(object):
         if not data.endswith(eol) or not (len(data) == reply['bytes']+2):
             raise errors.ExpectedCrlf('Data not properly sent from server')
 
-        reply['data'] = resp.parsefunc(data.rstrip(eol))
+        reply['data'] = resp.parsefunc(data[:reply['bytes']])
         yield reply
         return
 


### PR DESCRIPTION
`rstrip` isn't limited to stripping only the two last characters. For example `'mymessage\n\r\n'.rstrip('\r\n')` will yield `'mymessage'`.

This causes information loss when reserving a job.

### Bug

```python
In [1]: import beanstalk

In [2]: bs = beanstalk.serverconn.ServerConn('localhost', 11300)
No handlers could be found for logger "beanstalk.serverconn"

In [3]: bs.put('message ending with a newline\n')
Out[3]: {'jid': 29839, 'state': 'ok'}

In [4]: bs.reserve()
Out[4]: 
{'bytes': 30,
 'data': 'message ending with a newline',
 'jid': 29839,
 'state': 'ok'}
```

As you can see, the trailing newline is lost.

### Fix

We know the size of the data, as it is explicitly mentionned in `reply['bytes']`. Moreover, the condition right above ensures the length is consistent between the actual reply length and the bytes field.

Truncating the data using the length in *bytes* field is more explicit and safe than stripping.